### PR TITLE
feat: lemmy

### DIFF
--- a/find_posts.py
+++ b/find_posts.py
@@ -469,11 +469,12 @@ def parse_user_url(url):
     if match is not None:
         return match
 
-    match = parse_pixelfed_profile_url(url)
+    match = parse_lemmy_profile_url(url)
     if match is not None:
         return match
 
-    match = parse_lemmy_profile_url(url)
+# Pixelfed profile paths do not use a subdirectory, so we need to match for them last.
+    match = parse_pixelfed_profile_url(url)
     if match is not None:
         return match
 
@@ -493,12 +494,12 @@ def parse_url(url, parsed_urls):
             parsed_urls[url] = match
 
     if url not in parsed_urls:
-        match = parse_pixelfed_url(url)
+        match = parse_lemmy_url(url)
         if match is not None:
             parsed_urls[url] = match
 
     if url not in parsed_urls:
-        match = parse_lemmy_url(url)
+        match = parse_pixelfed_url(url)
         if match is not None:
             parsed_urls[url] = match
 

--- a/find_posts.py
+++ b/find_posts.py
@@ -397,7 +397,8 @@ def get_all_known_context_urls(server, reply_toots, parsed_urls):
             parsed_url = parse_url(url, parsed_urls)
             context = get_toot_context(parsed_url[0], parsed_url[1], url)
             if context is not None:
-                known_context_urls.update(context) # type: ignore
+                for item in context:
+                    known_context_urls.add(item)
             else:
                 log(f"Error getting context for toot {url}")
     


### PR DESCRIPTION
Parses `/comment/` and `/post/` URLs for comment IDs to use with [getComment](https://join-lemmy.org/api/classes/LemmyHttp.html#getComment) to obtain the parent `post_id` and then uses [getComments](https://join-lemmy.org/api/classes/LemmyHttp.html#getComments) to find all related comment URLs under `ap_id`.