### PR TITLE
fix: handle zero notifications

### DIFF
--- a/find_posts.py
+++ b/find_posts.py
@@ -795,12 +795,30 @@ def get_paginated_mastodon(url, max, headers = {}, timeout = 0, max_tries = 5):
     if(isinstance(max, int)):
         while len(result) < max and 'next' in response.links:
             response = get(response.links['next']['url'], headers, timeout, max_tries)
-            result = result + response.json()
+            if response.status_code != 200:
+                raise Exception(
+                    f"Error getting URL {response.url}. \
+                        Status code: {response.status_code}"
+                )
+            response_json = response.json()
+            if isinstance(response_json, list):
+                result += response_json
+            else:
+                break
     else:
-        while parser.parse(result[-1]['created_at']) >= max and 'next' in response.links:
+        while result and parser.parse(result[-1]['created_at']) >= max \
+            and 'next' in response.links:
             response = get(response.links['next']['url'], headers, timeout, max_tries)
-            result = result + response.json()
-    
+            if response.status_code != 200:
+                raise Exception(
+                    f"Error getting URL {response.url}. \
+                        Status code: {response.status_code}"
+                )
+            response_json = response.json()
+            if isinstance(response_json, list):
+                result += response_json
+            else:
+                break
     return result
 
 


### PR DESCRIPTION
## Expected Behavior
<!--- Tell us what should happen -->
When `from-notifications > 0`:
	When a user has notifications, fetch context.
	When a user does not have notifications, continue to the next step.

## Current Behavior
<!--- Tell us what happens instead of the expected behavior -->
When a user has no notifications, `/api/v1/notifications` returns `[]`.

```log
2023-07-02 23:52:37.204976 Eastern Daylight Time: Getting notifications for last 10 hours
2023-07-02 23:52:37.277612 Eastern Daylight Time: Job failed after 0:00:00.480230.
Traceback (most recent call last):
  File "{...}}\FediFetcher\find_posts.py", line 1053, in <module>
    notification_users = get_notification_users(arguments.server, token, all_known_users, arguments.from_notifications)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{...}\FediFetcher\find_posts.py", line 43, in get_notification_users
    notifications = get_paginated_mastodon(f"https://{server}/api/v1/notifications", since, headers={
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "{...}\FediFetcher\find_posts.py", line 800, in get_paginated_mastodon
    while parser.parse(result[-1]['created_at']) >= max and 'next' in response.links:
                       ~~~~~~^^^^
IndexError: list index out of range
```

We encounter `IndexError: list index out of range` when trying to access `result[-1]`.

## Possible Solution
<!--- Not obligatory, but suggest a fix/reason for the bug, -->
Use [isInstance()](https://www.w3schools.com/python/ref_func_isinstance.asp) to check if result is of type `list` before assigning it, use `while result and...` instead of `while ...`, and provide some additional error handling surrounding the request.

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug. Include code to reproduce, if relevant -->
1. Clear all notifications in Mastodon.
2. Set `from-notifications` to any value greater than `0`.
3. Run FediFetcher and reach the get_notification_users function.
4. See failed run, check logs.

## Context (Environment)
<!--- How has this issue affected you? What are you trying to accomplish? -->
<!--- Providing context helps us come up with a solution that is most useful in the real world -->
This will cause the job to fail, causing a notification if using GitHub Actions, and it **will not save `seen_urls` into `./artifacts` if the program exits ungracefully,** causing a growing backlog of reprocessed-posts every time it attempts to run on schedule again. Ideally, exceptions from these functions should at the very least lead to a graceful exit where artifacts are still attempted to be written, and is worth its own PR.
