### PR TITLE
add hacky support for misskey and calckey/firefish

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Option | Required? | Notes |
 |`backfill-with-context` | No | Set to `0` to disable fetching remote replies while backfilling profiles. This is enabled by default, but you can disable it, if it's too slow for you.
 |`backfill-mentioned-users` | No | Set to `0` to disable backfilling any mentioned users when fetching the home timeline. This is enabled by default, but you can disable it, if it's too slow for you.
 | `remember-users-for-hours` | No | How long between back-filling attempts for non-followed accounts? Defaults to `168`, i.e. one week.
+| `remember-hosts-for-days` | No | How long should FediFetcher cache host info for? Defaults to `30`.
 | `http-timeout` | No | The timeout for any HTTP requests to the Mastodon API in seconds. Defaults to `5`.
 | `lock-hours` | No | Determines after how many hours a lock file should be discarded. Not relevant when running the script as GitHub Action, as concurrency is prevented using a different mechanism. Recommended value: `24`.
 | `lock-file` | No | Location for the lock file. If not specified, will use `lock.lock` under the state directory. Not relevant when running the script as GitHub Action.

--- a/find_posts.py
+++ b/find_posts.py
@@ -1291,6 +1291,7 @@ if __name__ == "__main__":
         REPLIED_TOOT_SERVER_IDS_FILE = os.path.join(arguments.state_dir, "replied_toot_server_ids")
         KNOWN_FOLLOWINGS_FILE = os.path.join(arguments.state_dir, "known_followings")
         RECENTLY_CHECKED_USERS_FILE = os.path.join(arguments.state_dir, "recently_checked_users")
+        SEEN_HOSTS_FILE = os.path.join(arguments.state_dir, "seen_hosts")
 
 
         seen_urls = OrderedSet([])
@@ -1325,7 +1326,11 @@ if __name__ == "__main__":
         all_known_users = OrderedSet(list(known_followings) + list(recently_checked_users))
 
         # NOTE: explicitly not cached in a file so we get server version upgrades or migrations to new software
-        seen_hosts = {}
+        if os.path.exists(SEEN_HOSTS_FILE):
+            with open(SEEN_HOSTS_FILE, "r", encoding="utf-8") as f:
+                seen_hosts = json.load(f)
+        else:
+            seen_hosts = {}
 
         if(isinstance(arguments.access_token, str)):
             setattr(arguments, 'access_token', [arguments.access_token])
@@ -1420,6 +1425,9 @@ if __name__ == "__main__":
 
         with open(RECENTLY_CHECKED_USERS_FILE, "w", encoding="utf-8") as f:
             recently_checked_users.toJSON()
+
+        with open(SEEN_HOSTS_FILE, "w", encoding="utf-8") as f:
+            json.dump(seen_hosts, f)
 
         os.remove(LOCK_FILE)
 

--- a/find_posts.py
+++ b/find_posts.py
@@ -738,7 +738,7 @@ def get_mastodon_urls(webserver, toot_id, toot_url):
         reset = datetime.strptime(resp.headers['x-ratelimit-reset'], '%Y-%m-%dT%H:%M:%S.%fZ')
         log(f"Rate Limit hit when getting context for {toot_url}. Waiting to retry at {resp.headers['x-ratelimit-reset']}")
         time.sleep((reset - datetime.now()).total_seconds() + 1)
-        return get_toot_context(server, toot_id, toot_url, seen_hosts)
+        return get_mastodon_urls(webserver, toot_id, toot_url)
 
     log(
         f"Error getting context for toot {toot_url}. Status code: {resp.status_code}"

--- a/find_posts.py
+++ b/find_posts.py
@@ -1373,6 +1373,9 @@ if __name__ == "__main__":
                     serverAge = datetime.now(serverInfo['last_checked'].tzinfo) - serverInfo['last_checked']
                     if(serverAge.total_seconds() > arguments.remember_hosts_for_days * 24 * 60 * 60 ):
                         seen_hosts.pop(host)
+                    elif('info' in serverInfo and serverInfo['info'] == None and serverAge.total_seconds() > 60 * 60 ):
+                        # Don't cache failures for more than 24 hours
+                        seen_hosts.pop(host)
         else:
             seen_hosts = ServerList({})
 

--- a/find_posts.py
+++ b/find_posts.py
@@ -1189,10 +1189,13 @@ def get_server_info(server, seen_hosts):
 def set_server_apis(server):
     # support for new server software should be added here
     software_apis = {
-        'mastodonApiSupport': ['mastodon', 'pleroma', 'akkoma', 'pixelfed', 'gotosocial', 'hometown'],
+        'mastodonApiSupport': ['mastodon', 'pleroma', 'akkoma', 'pixelfed', 'hometown'],
         'misskeyApiSupport': ['misskey', 'calckey', 'firefish', 'foundkey'],
         'lemmyApiSupport': ['lemmy']
     }
+
+    # software that has specific API support but is not compatible with FediFetcher for various reasons:
+    # * gotosocial - All Mastodon APIs require access token (https://github.com/superseriousbusiness/gotosocial/issues/2038)
 
     for api, softwareList in software_apis.items():
         server[api] = server['software'] in softwareList

--- a/find_posts.py
+++ b/find_posts.py
@@ -1089,7 +1089,7 @@ class OrderedSet:
         return len(self._dict)
     
     def toJSON(self):
-        return json.dump(self._dict, f, default=str)
+        return json.dumps(self._dict,default=str)
 
 def get_server_from_host_meta(server):
     url = f'https://{server}/.well-known/host-meta'
@@ -1468,7 +1468,7 @@ if __name__ == "__main__":
             json.dump(dict(list(replied_toot_server_ids.items())[-10000:]), f)
 
         with open(RECENTLY_CHECKED_USERS_FILE, "w", encoding="utf-8") as f:
-            recently_checked_users.toJSON()
+            f.write(recently_checked_users.toJSON())
 
         with open(SEEN_HOSTS_FILE, "w", encoding="utf-8") as f:
             f.write(seen_hosts.toJSON())

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests==2.28.2
 six==1.16.0
 smmap==5.0.0
 urllib3==1.26.14
+defusedxml==0.7.1


### PR DESCRIPTION
Fixes #60

This implementation is not very robust and doesn't actually do the work to detect the server type to use (like mentioned in #60) and just relies on fallbacks. Also, in testing it seems like the `url` field for notes on Misskey/Firefish servers aren't actually filled in so they have to be created manually from the server and note ID, at least on the two servers I tested (misskey.io and calckey.social).