### PR TITLE
examples/k8s-cronjob.yaml: fix job naming

### DIFF
--- a/examples/k8s-cronjob.yaml
+++ b/examples/k8s-cronjob.yaml
@@ -14,7 +14,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: FediFetcher
+  name: fedifetcher
 spec:
   # Run every 2 hours
   schedule: "0 */2 * * *"
@@ -30,7 +30,7 @@ spec:
               persistentVolumeClaim:
                 claimName: fedifetcher-pvc
           containers:
-            - name: FediFetcher
+            - name: fedifetcher
               image: ghcr.io/nanos/fedifetcher:latest
               args:
                 - --server=your.server.social


### PR DESCRIPTION
Fixes validation errors upon applying the k8s manifest:

```
The CronJob "FediFetcher" is invalid:
* metadata.name: Invalid value: "FediFetcher": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
* spec.jobTemplate.spec.template.spec.containers[0].name: Invalid value: "FediFetcher": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```