### PR TITLE
Add sharkey as misskey-api-capable

### DIFF
--- a/find_posts.py
+++ b/find_posts.py
@@ -1219,7 +1219,7 @@ def set_server_apis(server):
     # support for new server software should be added here
     software_apis = {
         'mastodonApiSupport': ['mastodon', 'pleroma', 'akkoma', 'pixelfed', 'hometown', 'iceshrimp'],
-        'misskeyApiSupport': ['misskey', 'calckey', 'firefish', 'foundkey'],
+        'misskeyApiSupport': ['misskey', 'calckey', 'firefish', 'foundkey', 'sharkey'],
         'lemmyApiSupport': ['lemmy']
     }
 


### PR DESCRIPTION
Closes #97 

Sharkey is a soft fork of misskey, and they also have the misskey api. (https://docs.joinsharkey.org/docs/getting-started/overview/)
I guess FediFetcher should use the misskey api
I tested against a few servers running 2024.2.0-beta.12 sharkey and it seemed to work fine.