### PR TITLE
Include access token when fetching user followers/followings

### DIFF
--- a/find_posts.py
+++ b/find_posts.py
@@ -301,9 +301,11 @@ def filter_known_users(users, known_users):
         users
     ))
 
-def get_new_followers(server, user_id, max, known_followers):
+def get_new_followers(server, user_id, access_token, max, known_followers):
     """Get any new followings for the specified user, up to the max number provided"""
-    followers = get_paginated_mastodon(f"https://{server}/api/v1/accounts/{user_id}/followers", max)
+    followers = get_paginated_mastodon(f"https://{server}/api/v1/accounts/{user_id}/followers", max, {
+        "Authorization": f"Bearer {access_token}",
+    })
 
     # Remove any we already know about
     new_followers = filter_known_users(followers, known_followers)
@@ -312,9 +314,11 @@ def get_new_followers(server, user_id, max, known_followers):
 
     return new_followers
 
-def get_new_followings(server, user_id, max, known_followings):
+def get_new_followings(server, user_id, access_token, max, known_followings):
     """Get any new followings for the specified user, up to the max number provided"""
-    following = get_paginated_mastodon(f"https://{server}/api/v1/accounts/{user_id}/following", max)
+    following = get_paginated_mastodon(f"https://{server}/api/v1/accounts/{user_id}/following", max, {
+        "Authorization": f"Bearer {access_token}",
+    })
 
     # Remove any we already know about
     new_followings = filter_known_users(following, known_followings)
@@ -1698,13 +1702,13 @@ if __name__ == "__main__":
             if arguments.max_followings > 0:
                 logger.info(f"Getting posts from last {arguments.max_followings} followings")
                 user_id = get_user_id(arguments.server, arguments.user, token)
-                followings = get_new_followings(arguments.server, user_id, arguments.max_followings, all_known_users)
+                followings = get_new_followings(arguments.server, user_id, token, arguments.max_followings, all_known_users)
                 add_user_posts(arguments.server, token, followings, known_followings, all_known_users, seen_urls, seen_hosts)
 
             if arguments.max_followers > 0:
                 logger.info(f"Getting posts from last {arguments.max_followers} followers")
                 user_id = get_user_id(arguments.server, arguments.user, token)
-                followers = get_new_followers(arguments.server, user_id, arguments.max_followers, all_known_users)
+                followers = get_new_followers(arguments.server, user_id, token, arguments.max_followers, all_known_users)
                 add_user_posts(arguments.server, token, followers, recently_checked_users, all_known_users, seen_urls, seen_hosts)
 
             if arguments.max_follow_requests > 0:

--- a/tests/test_find_posts.py
+++ b/tests/test_find_posts.py
@@ -448,14 +448,17 @@ def test_get_new_followers(
 
     server = "server"
     user_id = 1
+    access_token = "access_token"
     max = 50
     known_followers = ["follower1"]
 
     expected_result = ["follower2", "follower3"]
-    result = find_posts.get_new_followers(server, user_id, max, known_followers)
+    result = find_posts.get_new_followers(server, user_id, access_token, max, known_followers)
 
     mock_get_paginated_mastodon.assert_called_once_with(
-        f"https://{server}/api/v1/accounts/{user_id}/followers", max
+        f"https://{server}/api/v1/accounts/{user_id}/followers", max, {
+            "Authorization": f"Bearer {access_token}",
+        },
     )
     mock_filter_known_users.assert_called_once_with(
         ["follower1", "follower2", "follower3"], known_followers
@@ -473,9 +476,11 @@ def test_get_new_followings(
 ):
     mock_get_paginated_mastodon.return_value = ["user1", "user2", "user3"]
     mock_filter_known_users.return_value = ["user1", "user2"]
-    result = get_new_followings("server", "100", 5, "known_users")
+    result = get_new_followings("server", "100", "access_token", 5, "known_users")
     mock_get_paginated_mastodon.assert_called_with(
-        "https://server/api/v1/accounts/100/following", 5
+        "https://server/api/v1/accounts/100/following", 5, {
+            "Authorization": "Bearer access_token",
+        }
     )
     mock_filter_known_users.assert_called_with(
         ["user1", "user2", "user3"], "known_users"


### PR DESCRIPTION
GoToSocial requires authentication on these endpoints, and not supplying the token was causing these requests to fail with a 401 error.

As far as I can tell, these calls only ever hit the configured server, and there shouldn't be any issues with providing a token when it isn't required, so I don't think there's any problems with this change. Tested it against my own GoToSocial instance and follower information is fetched with no problems.

Fixes #117.