### PR TITLE
Bumped requirements to 2.32.3 as 2.32.0 was yanked

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ packaging==24.1
 pluggy==1.5.0
 pytest==8.2.2
 python-dateutil==2.8.2
-requests==2.32.0
+requests==2.32.3
 six==1.16.0
 smmap==5.0.0
 urllib3==1.26.19


### PR DESCRIPTION
Fixes #191 

I don't think any of the problems that caused 2.32.0 are likely to affect this project, but better to use the clean version.