### PR TITLE
Temporarily disable keepalive-workflow

### DIFF
--- a/.github/workflows/get_context.yml
+++ b/.github/workflows/get_context.yml
@@ -37,7 +37,8 @@ jobs:
           name: artifacts
           path: |
             artifacts
-      - name: Checkout user's forked repository for keeping workflow alive
-        uses: actions/checkout@v4
-      - name: Keep workflow alive
-        uses: gautamkrishnar/keepalive-workflow@v1
+      # Temporarily disable these while we figure out what to do.
+      # - name: Checkout user's forked repository for keeping workflow alive
+      #   uses: actions/checkout@v4
+      # - name: Keep workflow alive
+      #   uses: gautamkrishnar/keepalive-workflow@v1


### PR DESCRIPTION
This is because the repo has been disabled by GitHub. See Missing download info for gautamkrishnar/keepalive-workflow@v1 #198 for detals