### PR TITLE
allow using FF_USER for the user setting

### DIFF
--- a/find_posts.py
+++ b/find_posts.py
@@ -1515,6 +1515,7 @@ if __name__ == "__main__":
             # most settings are numerical
             if envvar not in [
                 "server",
+                "user",
                 "lock_file",
                 "state_dir",
                 "on_start",


### PR DESCRIPTION
Currently, when using the `FF_USER` env var, it fails with a parse error on trying to `int()` the username.